### PR TITLE
mgr: Use signed int log level in PyModules::log()

### DIFF
--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -446,7 +446,7 @@ void PyModules::insert_config(const std::map<std::string,
 }
 
 void PyModules::log(const std::string &handle,
-    unsigned level, const std::string &record)
+    int level, const std::string &record)
 {
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr[" << handle << "] "

--- a/src/mgr/PyModules.h
+++ b/src/mgr/PyModules.h
@@ -83,7 +83,7 @@ public:
       const std::string &key, const std::string &val);
 
   void log(const std::string &handle,
-           unsigned level, const std::string &record);
+           int level, const std::string &record);
 };
 
 #endif


### PR DESCRIPTION
Using an unsigned causes a build failure when expanding the dout macro.

Signed-off-by: Tim Serong <tserong@suse.com>