### PR TITLE
[RFC] mgr: DeepSea orchestrator module

### DIFF
--- a/src/pybind/mgr/deepsea/__init__.py
+++ b/src/pybind/mgr/deepsea/__init__.py
@@ -1,0 +1,1 @@
+from .module import Module

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -1,0 +1,354 @@
+# vim: ts=8 et sw=4 sts=4
+"""
+Highly Experimental DeepSea Orchestrator
+"""
+
+import errno
+import json
+import requests
+
+from threading import Event, Thread
+
+from mgr_module import MgrModule
+from orchestrator import *
+
+class RequestException(Exception):
+    def __init__(self, message, status_code=None):
+        super(RequestException, self).__init__(message)
+        self.status_code = status_code
+
+
+class Module(MgrModule, Orchestrator):
+    config = dict()
+    config_keys = {
+        'salt_api_host': None,
+        'salt_api_port': '8000',
+        'salt_api_ssl': 'false',
+        'salt_api_eauth': 'sharedsecret',
+        'salt_api_username': None,
+        'salt_api_password': None
+    }
+
+    COMMANDS = [
+        {
+            "cmd": "deepsea config-set name=key,type=CephString "
+                   "name=value,type=CephString",
+            "desc": "Set a configuration value",
+            "perm": "rw"
+        },
+        {
+            "cmd": "deepsea config-show",
+            "desc": "Show current configuration",
+            "perm": "r"
+        },
+        {
+            "cmd": "deepsea get-inventory",
+            "desc": "Get inventory",
+            "perm": "r"
+        },
+        {
+            "cmd": "deepsea add-stateless-service name=type,type=CephString",
+            "desc": "Add stateless service",
+            "perm": "rw"
+        }
+    ]
+
+
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        self.event = Event()
+        self.token = None
+
+
+    def _config_valid(self):
+        for key in self.config_keys:
+            self.config[key] = self.get_config(key, default=self.config_keys[key])
+            if not self.config[key]:
+                return False
+        return True
+
+
+    def handle_command(self, cmd):
+        if cmd['prefix'] == 'deepsea config-show':
+            return 0, json.dumps(self.config), ''
+
+        elif cmd['prefix'] == 'deepsea config-set':
+            if cmd['key'] not in self.config_keys.keys():
+                return (-errno.EINVAL, '',
+                        "Unknown configuration option '{0}'".format(cmd['key']))
+
+            self.config[cmd['key']] = cmd['value']
+            self.set_config(cmd['key'], cmd['value'])
+            self.event.set()
+            return 0, "Configuration option '{0}' updated".format(cmd['key']), ''
+
+        elif cmd['prefix'] == 'deepsea get-inventory':
+            # for dev/test purposes
+            try:
+                inventory = self.get_inventory()
+                return 0, "\n".join([n.name for n in inventory]), ''
+
+            except Exception as ex:
+                return -errno.EINVAL, '', str(ex)
+
+        elif cmd['prefix'] == 'deepsea add-stateless-service':
+            # for dev/test purposes
+            try:
+                ret = self.add_stateless_service(cmd['type'])
+                return 0, str(ret), ''
+
+            except Exception as ex:
+                return -errno.EINVAL, '', str(ex)
+
+        return (-errno.EINVAL, '',
+                "Command not found '{0}'".format(cmd['prefix']))
+
+
+    def serve(self):
+        self.log.info('DeepSea module starting up')
+        self.run = True
+        self._event_reader = None
+        self._reading_events = False
+
+        while self.run:
+            if not self._config_valid():
+                # This will spin until the config is valid, spitting a warning
+                # that the config is invalid every 60 seconds.  The one oddity
+                # is that while setting the various parameters, this log warning
+                # will print once for each parameter set until the config is    
+                # valid.
+                self.log.warn("Configuration invalid; try `ceph deepsea config-set [...]`")
+                self.event.wait(60)
+                self.event.clear()
+                continue
+
+            if self._event_reader and not self._reading_events:
+                self._event_reader = None
+
+            if not self._event_reader:
+                try:
+                    # This spawns a separate thread to read the salt event bus
+                    # stream.  We can't do it in the serve thead, because reading
+                    # from the response blocks, which would prevent the serve
+                    # thread from handling anything else.
+                    self._event_response = self._do_request_with_login("GET", "events", stream=True)
+                    self._event_reader = Thread(target=self._read_sse)
+                    self._reading_events = True
+                    self._event_reader.start()
+                except Exception as ex:
+                    self.log.warn("Failure setting up event reader: " + str(ex))
+                    # gives an (arbitrary) 5 second retry if we can't attach to
+                    # the salt-api event bus for some reason
+                    # TODO: increase this and/or make it configurable
+                    self.event.wait(5)
+                    self.event.clear()
+                    continue
+
+            # Wait indefinitely for something interesting to happen (e.g.
+            # config-set, or shutdown), or the event reader to fail, which
+            # will happen if the salt-api server dies or restarts).
+            # TODO: figure out how to restart the _event_reader thread if
+            # config changes, e.g.: a new username or password is set.
+            self.event.wait()
+            self.event.clear()
+
+
+    # Reader/parser of SSE events, see:
+    # - https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#events)
+    # - https://www.w3.org/TR/2009/WD-eventsource-20090421/
+    # Note: this is pretty braindead and doesn't implement the full eventsource
+    # spec, but it *does* implement enough for us to listen to events from salt
+    # and potentially do something with them.
+    def _read_sse(self):
+        event = {}
+        try:
+            for line in self._event_response.iter_lines():
+                if line:
+                    line = line.decode('utf-8')
+                    colon = line.find(':')
+                    if colon > 0:
+                        k = line[:colon]
+                        v = line[colon+2:]
+                        if k == "retry":
+                            # TODO: find out if we need to obey this reconnection time
+                            self.log.warn("Server requested retry {}, ignored".format(v))
+                        else:
+                            event[k] = v
+                else:
+                    # Empty line, terminates an event.  Note that event['tag']
+                    # is a salt-api extension to SSE to avoid having to decode
+                    # json data if you don't care about it.  To get to the
+                    # interesting stuff, you want event['data'], which is json.
+                    self.log.info("Got event '{}'".format(str(event)))
+
+                    # If we actually wanted to do something with the event,
+                    # say, we want to notice that some long salt run has
+                    # finished, we'd call some notify method here (TBD).
+
+                    # If you want to have some fun, try `salt '*' test.ping`
+                    # on the master while this module is running with
+                    # "debug_mgr 4/5", and tail the mgr log.
+                    event = {}
+            self.log.warn("SSE read terminated")
+        except Exception as ex:
+            self.log.warn("SSE read failed: {}".format(str(ex)))
+
+        self._reading_events = False
+        self.event.set()
+
+
+    def shutdown(self):
+        self.log.info('DeepSea module shutting down')
+        self.run = False
+        self.event.set()
+
+
+    # This blocks until it gets the full list of nodes back from salt, and
+    # returns a list of InventoryNode()s.
+    #
+    # To implement this in nonblocking form, internally it could use the
+    # runner_async client which would give a salt job ID.  _read_sse() could
+    # then notice when that job was complete, and...  How would it tell the
+    # caller of get_inventory() that the inventory had arrived?
+    #
+    # TODO: populate devices[] for each node?  (I'm not aware of an obvious
+    # way to extract this from DeepSea in a hurry).
+    def get_inventory(self, node_filter=None):
+        resp = self._do_request_with_login("POST", data = {
+            "client": "runner",
+            "fun": "select.minions",
+            "cluster": "ceph"
+            # could add "role:" here to get individual roles
+            # if node_filter was requested (DeepSea role should map to
+            # Orchestrator label concept)
+        })
+
+        # This is really cumbersome.  Possibly I should be subclassing
+        # InventoryNode() to provide a constructor that takes a hostname,
+        # then this could just be a nice little generator.
+        inventory = list()
+        for hostname in resp.json()["return"][0]:
+            node = InventoryNode()
+            node.name = hostname
+            inventory.append(node)
+
+        # Note: hosts are returned by salt in an arbitrary, unsorted order.
+        return inventory
+
+
+    # This one is...  Interesting.
+    #
+    # See, DeepSea has a policy.cfg file, where the admin defines what roles
+    # each node has.  Any node with "role-rgw" assigned is where DeepSea will
+    # go and install radosgw.  Usually with DeepSea, once you've run through
+    # stages 0-3, you've got a Ceph cluster up with MONs, OSDs and MGRs, but
+    # "optional" pieces like RGW and MDS, Ganesha and iSCSI gateways
+    # are all deployed when you run stage 4.  These things could equally be
+    # deployed with this add_stateless_service function (instead of running
+    # stage 4), but it's a pretty blunt instrument:
+    #
+    # - Calling this with service_type=rgw will tell DeepSea to deploy rgw
+    #   on all the nodes with role-rgw assigned, so StatelessServiceSpec()
+    #   kinda doesn't really serve any purpose.
+    # - Calling this with service_type=mds would (were it implemented) tell
+    #   DeepSea to deploiy mds on all the nodes with role-mds, and DeepSea
+    #   would *also* automatically go create the CephFS pools.
+    #
+    # It also takes a damnably long time to run, and if it completes
+    # successfully returns a huge pile of status information for all the salt
+    # stuff that happened.
+    #
+    # This one really wants to be async (using runner_async and having
+    # _read_sse() expect events indicating the job is complete), but again,
+    # the caller needs some means of knowing the job is actually complete.
+    #
+    def add_stateless_service(self, service_type, spec=None):
+        if service_type == "rgw":
+            resp = self._do_request_with_login("POST", data = {
+                "client": "runner",
+                "fun": "state.orch",
+                "arg": ["ceph.stage.radosgw"]
+            })
+            return resp.json()["return"]
+
+        raise NotImplementedError()
+
+
+    # I'm fairly certain this doesn't make sense for DeepSea, given
+    # StatelessServiceSpec() doesn't make sense (see above comment)
+    def update_stateless_service(self, service_type, id_, spec):
+        raise NotImplementedError()
+
+
+    # This is impossible with DeepSea right now (DeepSea will let you remove
+    # services, but to do so you have to go edit the policy.cfg file and
+    # run stage 5)
+    def remove_stateless_service(self, service_type, id_):
+        raise NotImplementedError()
+
+
+    # _do_request(), _login() and _do_request_with_login() are an extremely
+    # minimalist form of the following, with notably terse error handling:
+    # https://bitbucket.org/openattic/openattic/src/ce4543d4cbedadc21b484a098102a16efec234f9/backend/rest_client.py?at=master&fileviewer=file-view-default
+    # https://bitbucket.org/openattic/openattic/src/ce4543d4cbedadc21b484a098102a16efec234f9/backend/deepsea.py?at=master&fileviewer=file-view-default
+    # rationale:
+    # - I needed slightly different behaviour than in openATTIC (I want the
+    #   caller to read the response, to allow streaming the salt-api event bus)
+    # - I didn't want to pull in 400+ lines more code into this presently
+    #   experimental module, to save everyone having to review it ;-)
+
+    def _do_request(self, method, path="", data=None, stream=False):
+        """
+        returns the response, which the caller then has to read
+        """
+        protocol = 'https' if self.config['salt_api_ssl'].lower() != 'false' else 'http'
+        url = "{0}://{1}:{2}/{3}".format(protocol,
+                                         self.config['salt_api_host'],
+                                         self.config['salt_api_port'], path)
+        try:
+            if method.lower() == 'get':
+                resp = requests.get(url, headers = { "X-Auth-Token": self.token },
+                                    data=data, stream=stream)
+            elif method.lower() == 'post':
+                resp = requests.post(url, headers = { "X-Auth-Token": self.token },
+                                     data=data)
+
+            else:
+                raise RequestException("Method '{}' not supported".format(method.upper()))
+            if resp.ok:
+                return resp
+            else:
+                msg = "Request failed with status code {}".format(resp.status_code)
+                self.log.error(msg)
+                raise RequestException(msg, resp.status_code)
+        except requests.exceptions.ConnectionError as ex:
+            self.log.error(str(ex))
+            raise RequestException(str(ex))
+        except requests.exceptions.InvalidURL as ex:
+            self.log.error(str(ex))
+            raise RequestException(str(ex))
+
+
+    def _login(self):
+        resp = self._do_request('POST', 'login', data = {
+            "eauth": self.config['salt_api_eauth'],
+            "sharedsecret" if self.config['salt_api_eauth'] == 'sharedsecret' else 'password': self.config['salt_api_password'],
+            "username": self.config['salt_api_username']
+        })
+        self.token = resp.json()['return'][0]['token']
+        self.log.info("Salt API login successful")
+
+
+    def _do_request_with_login(self, method, path="", data=None, stream=False):
+        retries = 2
+        while True:
+            try:
+                if not self.token:
+                    self._login()
+                return self._do_request(method, path, data, stream)
+            except RequestException as ex:
+                retries -= 1
+                if ex.status_code not in [401, 403] or retries == 0:
+                    raise ex
+                self.token = None
+

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1,0 +1,266 @@
+
+"""
+ceph-mgr orchestrator interface
+
+This is a DRAFT for discussion.
+
+Goal: enable UI workflows for cluster service management
+      (such as creating OSDs, in addition to stateless services)
+      using common concepts that are implemented by
+      diverse backends such as Rook, DeepSea, ceph-ansible
+
+Concepts:
+    "Stateful service": a daemon that uses local storage, such as OSD or mon.
+    "Stateless service": a daemon that doesn't use any local storage, such
+                         as an MDS, RGW, nfs-ganesha, iSCSI gateway.
+    "Label": arbitrary string tags that may be applied by administrators
+             to nodes.  Typically administrators use labels to indicate
+             which nodes
+
+Constraints:
+    1. The orchestrator is to be the source of truth for
+       all the physical information, and will be queried directly
+       as needed (i.e. no in-Ceph database of hardware etc).
+    2. The orchestrator handles placement of collections of stateless
+       services.
+    3. The orchestrator accepts explicit placement of individual stateful
+       services, and optionally also accepts label-based automatic placement.
+       (i.e. it *must* support "create OSD at host1:/dev/sdb", and it *may*
+        support "create OSDs on hosts with label=ceph-osd")
+    4. Ceph is not responsible for installing anything on nodes, or hooking
+       up hosts to the orchestrator: nodes and drives only exist to Ceph
+       once they're exposed by the orchestrator.
+
+Flexible features:
+    1. Orchestrator may be aware of one or more "special features" for
+       block devices, such as block-level encryption.  These special
+       features may be reported during discovery or enabled during
+       OSD creation.
+    2. Orchestrator may not have a concept of labels: if it doesn't,
+       any label-filtered calls will match everything.
+
+Excluded functionality:
+    1. No support for multipathed drives: all block devices are to be
+    reported from one host only.
+    2. No networking inventory or configuration.
+
+This is a DRAFT for discussion.
+"""
+
+
+class Orchestrator(object):
+    """
+    All calls in this class are blocking on network IO and may
+    take noticeable length of time to run.  Wrap calls appropriately
+    in long-running task infrastructure when calling from interactive
+    code.
+    """
+
+    # >>> From 21 March meeting
+    def get_inventory(self, node_filter=None):
+        # Return list of InventoryHost
+        raise NotImplementedError()
+
+    def add_stateful_service(self, service_type, spec):
+        """
+        service_type: one of mon, osd
+        """
+        assert isinstance(spec, StatefulServiceSpec)
+        raise NotImplementedError()
+
+    def remove_stateful_service(self, service_type, service_id):
+        raise NotImplementedError()
+
+    def add_stateless_service(self, service_type, spec):
+        assert isinstance(spec, StatelessServiceSpec)
+        raise NotImplementedError()
+
+    def update_stateless_service(self, service_type, id_, spec):
+        assert isinstance(spec, StatelessServiceSpec)
+        raise NotImplementedError()
+
+    def remove_stateless_service(self, service_type, id_):
+        raise NotImplementedError()
+
+    def upgrade_start(self, upgrade_spec):
+        assert isinstance(upgrade_spec, UpgradeSpec)
+        raise NotImplementedError()
+
+    def upgrade_status(self):
+        """
+        If an upgrade is currently underway, report on where
+        we are in the process, or if some error has occurred.
+
+        :return: UpgradeStatusSpec instance
+        """
+        raise NotImplementedError()
+
+    def upgrade_available(self):
+        """
+        Report on what versions are available to upgrade to
+
+        :return: List of strings
+        """
+        raise NotImplementedError()
+    # <<< from 21 March meeting
+
+    # >>> additional to 21mar: auto-placement of stateful services
+    def add_stateful_service_rule(self, service_type, stateful_service_spec,
+                                  placement_spec):
+        """
+        Stateful service rules serve two purposes:
+         - Optionally delegate device selection to the orchestrator
+         - Enable the orchestrator to auto-assimilate new hardware if it
+           matches the placement spec, without any further calls from ceph-mgr.
+
+        To create a confidence-inspiring UI workflow, use test_stateful_service_rule
+        beforehand to show the user where stateful services will be placed
+        if they proceed.
+        """
+        raise NotImplementedError()
+
+    def test_stateful_service_rule(self, service_type, stateful_service_spec,
+                                   placement_spec):
+        """
+        See add_stateful_service_rule.
+        """
+        raise NotImplementedError()
+
+    def remove_stateful_service_rule(self, service_type, id_):
+        """
+        This will remove the *rule* but not the services that were
+        created as a result.  Those should be converted into statically
+        placed services as if they had been created with add_stateful_service,
+        so that they can be removed with remove_stateless_service
+        if desired.
+        """
+        raise NotImplementedError()
+    # <<<
+
+
+class UpgradeSpec(object):
+    # Request to orchestrator to initiate an upgrade to a particular
+    # version of Ceph
+    def __init__(self):
+        self.target_version = None
+
+
+class UpgradeStatusSpec(object):
+    # Orchestrator's report on what's going on with any ongoing upgrade
+    def __init__(self):
+        self.in_progress = False  # Is an upgrade underway?
+        self.services_complete = []  # Which daemon types are fully updated?
+        self.message = ""  # Freeform description
+
+
+class PlacementSpec(object):
+    """
+    For APIs that need to specify a node subset
+    """
+    def __init__(self):
+        self.label = None
+
+
+class StatefulServiceSpec(object):
+    """
+    Details of stateful service creation.
+
+    For OSDs this should map to what ceph-volume can do.
+    """
+
+    def __init__(self):
+        self.service_type = None  # osd, mon
+
+        self.format = None  # filestore, bluestore (meaningful for OSD only)
+
+        self.hostname = None
+
+        # Map role to device ID:
+        #   Valid keys: data (mon)
+        #   Valid keys: data, journal (filestore)
+        #   Valid keys: data, wal, db (bluestore)
+        self.block_devices = {}
+
+        # Arbitrary JSON-serializable object.
+        # Maybe your orchestrator knows how to do something
+        # special like encrypting drives
+        self.extended = {}
+
+
+class StatelessServiceSpec(object):
+    # Request to orchestrator for a group of stateless services
+    # such as MDS, RGW, nfs gateway, iscsi gateway
+    """
+    Details of stateless service creation.
+
+    This is *not* supposed to contain all the configuration
+    of the services: it's just supposed to be enough information to
+    execute the binaries.
+    """
+
+    def __init__(self):
+        self.placement = PlacementSpec()
+
+        # Give this set of statelss services a name: typically it would
+        # be the name of a CephFS pool, RGW zone, etc.  Must be unique
+        # within one ceph cluster.
+        self.name = ""
+
+        # Minimum and maximum number of service instances
+        self.min_size = 1
+        self.max_size = 1
+
+        # Arbitrary JSON-serializable object.
+        # Maybe you're using e.g. kubenetes and you want to pass through
+        # some replicaset special sauce for autoscaling?
+        self.extended = {}
+
+
+class InventoryFilter(object):
+    """
+    When fetching inventory, use this filter to avoid unnecessarily
+    scanning the whole estate.
+
+    Typical use: filter by host when presenting UI workflow for configuring
+                 a particular server.
+                 filter by label when not all of estate is Ceph servers,
+                 and we want to only learn about the Ceph servers.
+                 filter by label when we are interested particularly
+                 in e.g. OSD servers.
+
+    """
+    def __init__(self):
+        self.labels = None  # Optional: get info about nodes matching labels
+        self.hostnames = None  # Optional: get info about certain hosts only
+
+
+class InventoryBlockDevice(object):
+    """
+    When fetching inventory, block devices are reported in this format.
+
+    Note on device identifiers: the format of this is up to the orchestrator,
+    but the same identifier must also work when passed into StatefulServiceSpec
+
+    "Extended" is for reporting any special configuration that may have
+    already been done out of band on the block device.  For example, if
+    the device has already been configured for encryption, report that
+    here so that it can be indicated to the user.  The set of
+    extended properties may differ between orchestrators.  An orchestrator
+    is permitted to support no extended properties (only normal block
+    devices)
+    """
+    def __init__(self):
+        self.blank = False
+        self.type = None  # 'ssd', 'hdd', 'nvme'
+        self.id = None  # unique within a node (or globally if you like).
+        self.size = None  # byte integer.
+        self.extended = None  # arbitrary JSON-serializable object
+
+        # TODO: should we report a "size_avail" to indicate a partially
+        # used device (has some journal partitions but also room for more?)
+
+
+class InventoryNode(object):
+    def __init__(self):
+        self.hostname = None  # unique within cluster
+        self.devices = []  # list of InventoryBlockDevice


### PR DESCRIPTION
This is a little experiment to see what a concrete implementation of the
Orchestrator interface might look like, to try to help explore the API,
and see how it fits with DeepSea's view of the world, without making
any changes to DeepSea.  Here's what we've got so far:

- Something that listens to the salt-api event bus, so we can talk to
  DeepSea asynchronously if we want (e.g. fire off a runner and wait
  for the job to complete).  Note that actually using this probably
  requires some callback or notification mechanism be added to the
  Orchestrator interface (see the comment on get_inventory() for
  example).

- A trivial implementation of get_inventory(), which doesn't return
  any block device information, but does at least give hostnames.

- An experimental implementation of add_stateless_service() for adding
  RGW instances, but see the comments in the file for caveats about
  stateless services and DeepSea's notion of roles.

- Two CLI commands (get-inventory and add-stateless-service) to
  exercise the above.

I've notably not attempted stateful service deployment, because I'm
not sure this actually makes sense from DeepSea's perspective.
The admin has to assign roles for MON and OSD nodes by editing a
policy.cfg file; if they're doing that, once they've edited that file,
the next step is to run DeepSea's "stage 3" to deploy the MONs and OSDs.
If you're on the salt-master editing policy.cfg, you probably just want
to run stage 3 then and there, not switch back to some other interface
which would then invoke this Orchestrator module.

I looked at the upgrade APIs, but implementing these would require
changes to DeepSea as well; DeepSea will happily run upgrades for you
in stage 0, but I don't think there's any way to query DeepSea to ask
what new versions are available, and also DeepSea will go upgrade
any available software, not just Ceph.  Actually, now that I've written
all that out, a trivial implementation of upgrade_start() and
upgrade_status() would be to simply trigger DeepSea's "stage 0", then
have the mgr module monitor that job for completion, and return
whatever it knows when someone later calls upgrade_status().  I should
probably try implementing that and see what happens.

If you'd like to play with this module right now on a live system,
just copy src/pybind/mgr/orchestrator.py and src/pybind/mgr/deepsea/
to /usr/lib64/ceph/mgr/, restart ceph-mgr, then run:

````
  # ceph mgr module enable deepsea
  # ceph deepsea config-set salt_api_host $SALT_MASTER_HOSTNAME
  # ceph deepsea config-set salt_api_username admin
  # ceph deepsea config-set salt_api_password $SHAREDSECRET
````

You can use the sharedsecret from /etc/salt/master.d/sharedsecret.conf
on the salt master (real deployments should probably make a separate
username and password for ceph-mgr usage, and should also be configured
to use SSL).

Signed-off-by: Tim Serong <tserong@suse.com>